### PR TITLE
add input parsing to handle more inputs

### DIFF
--- a/tests/quantized_matmul.mlir
+++ b/tests/quantized_matmul.mlir
@@ -1,0 +1,13 @@
+"builtin.module"() ({
+  %0, %1, %2, %3, %4 = "test.op"() : () -> (memref<16x20xi8>, memref<20x24xi8>, i32, i32, memref<16x24xi32>)
+  "linalg.generic"(%0, %1, %2, %3, %4) <{"indexing_maps" = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> ()>, affine_map<(d0, d1, d2) -> ()>, affine_map<(d0, d1, d2) -> (d0, d1)>], "iterator_types" = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>], "operandSegmentSizes" = array<i32: 4, 1>}> ({
+  ^0(%arg3 : i8, %arg4 : i8, %arg5 : i32, %arg6 : i32, %arg7 : i32):
+    %5 = "arith.extsi"(%arg3) : (i8) -> i32
+    %6 = "arith.subi"(%5, %arg5) : (i32, i32) -> i32
+    %7 = "arith.extsi"(%arg4) : (i8) -> i32
+    %8 = "arith.subi"(%7, %arg6) : (i32, i32) -> i32
+    %9 = "arith.muli"(%6, %8) : (i32, i32) -> i32
+    %10 = "arith.addi"(%arg7, %9) : (i32, i32) -> i32
+    "linalg.yield"(%10) : (i32) -> ()
+  }) : (memref<16x20xi8>, memref<20x24xi8>, i32, i32, memref<16x24xi32>) -> ()
+}) : () -> ()

--- a/transforms/linalg_to_stream.py
+++ b/transforms/linalg_to_stream.py
@@ -9,11 +9,7 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
-from xdsl.dialects.builtin import (
-    ShapedType,
-    IntegerType,
-    IntAttr
-)
+from xdsl.dialects.builtin import ShapedType, IntegerType, IntAttr
 
 from util.kernel_type import KernelType
 
@@ -28,23 +24,28 @@ class LinalgToStreamTranslator(RewritePattern):
 
         if not kernel_type:
             return
-        
+
         # make some assertions correct outputs of the linalg generic
         # linalg should have one output, and it should be a shaped type
         if len(generic_op.outputs) != 1:
             return
         if not isinstance(generic_op.outputs[0].type, ShapedType):
             return
-        
+
         # extract output op and relevant indexing maps
         output_op = generic_op.outputs[0]
         output_map = generic_op.indexing_maps.data[-1].data
-        
+
         # make some assertions on correct inputs of the linalg generic
-        shaped_inputs = [(op, map.data) for (op, map) in zip(generic_op.inputs, generic_op.indexing_maps.data[:-1]) if isinstance(op.type, ShapedType)]
+        shaped_inputs = [
+            (op, map.data)
+            for (op, map) in zip(generic_op.inputs, generic_op.indexing_maps.data[:-1])
+            if isinstance(op.type, ShapedType)
+        ]
         if len(shaped_inputs) != 2:
             return
-        
+
+        # input a, input b, output
         operands = [shaped_inputs[0][0], shaped_inputs[1][0], output_op]
         indexing_maps = [shaped_inputs[0][1], shaped_inputs[1][1], output_map]
 
@@ -59,7 +60,7 @@ class LinalgToStreamTranslator(RewritePattern):
             map = indexing_maps[-1].results[i]
             assert isinstance(map, AffineDimExpr)
             output_access += f"[{str(map)}]"
-       
+
         input_i_access = "I"
         for i in range(len(indexing_maps[0].results)):
             map = indexing_maps[0].results[i]
@@ -73,14 +74,14 @@ class LinalgToStreamTranslator(RewritePattern):
             input_w_access += f"[{str(map)}]"
 
         if kernel_type == KernelType.MUL:
-            zigzag_description[
-                "equation"
-            ] = f"{output_access} = {input_i_access} * {input_w_access}"
+            zigzag_description["equation"] = (
+                f"{output_access} = {input_i_access} * {input_w_access}"
+            )
 
         elif kernel_type in (KernelType.MAC, KernelType.QMAC):
-            zigzag_description[
-                "equation"
-            ] = f"{output_access} += {input_i_access} * {input_w_access}"
+            zigzag_description["equation"] = (
+                f"{output_access} += {input_i_access} * {input_w_access}"
+            )
 
         # extract dimension_relations
         # for matmul, this is empty
@@ -107,19 +108,19 @@ class LinalgToStreamTranslator(RewritePattern):
         # extract operand precision
         widths = []
         for op in operands:
-            assert isinstance(op.type, memref.MemRefType)           
+            assert isinstance(op.type, memref.MemRefType)
             element_type = op.type.get_element_type()
-            if(isinstance(element_type, IntegerType)):
+            if isinstance(element_type, IntegerType):
                 widths.append(element_type.width.data)
             else:
                 widths.append(element_type.get_bitwidth)
-        
+
         zigzag_description["operand_precision"] = dict()
         zigzag_description["operand_precision"]["O"] = widths[-1]
         zigzag_description["operand_precision"]["O_final"] = widths[-1]
         zigzag_description["operand_precision"]["W"] = widths[0]
-        zigzag_description["operand_precision"]["I"] = widths[1]        
-  
+        zigzag_description["operand_precision"]["I"] = widths[1]
+
         # operand source (use default of no source for now)
         zigzag_description["operand_source"] = dict()
         zigzag_description["operand_source"]["W"] = []
@@ -132,9 +133,9 @@ class LinalgToStreamTranslator(RewritePattern):
         # padding (use default of 0 padding for now)
         # affects last two indices of input I
         zigzag_description["padding"] = dict()
-        zigzag_description["padding"][str(indexing_maps[0].results[0]).upper()] = (0,0)
-        zigzag_description["padding"][str(indexing_maps[0].results[1]).upper()] = (0,0)
-        workload= dict()
+        zigzag_description["padding"][str(indexing_maps[0].results[0]).upper()] = (0, 0)
+        zigzag_description["padding"][str(indexing_maps[0].results[1]).upper()] = (0, 0)
+        workload = dict()
         workload[0] = zigzag_description
 
         with open("workload.py", "w") as f:

--- a/transforms/linalg_to_stream.py
+++ b/transforms/linalg_to_stream.py
@@ -10,6 +10,7 @@ from xdsl.pattern_rewriter import (
     op_type_rewrite_pattern,
 )
 from xdsl.dialects.builtin import (
+    ShapedType,
     IntegerType,
     IntAttr
 )
@@ -27,14 +28,25 @@ class LinalgToStreamTranslator(RewritePattern):
 
         if not kernel_type:
             return
-
-        # zigzag -> 3 operands: 2 inputs, 1 output
-        assert len(generic_op.outputs) == 1
-        generic_op.outputs[0]
-
-        assert len(generic_op.inputs) == 2
-        generic_op.inputs[0]
-        generic_op.inputs[1]
+        
+        # make some assertions correct outputs of the linalg generic
+        # linalg should have one output, and it should be a shaped type
+        if len(generic_op.outputs) != 1:
+            return
+        if not isinstance(generic_op.outputs[0].type, ShapedType):
+            return
+        
+        # extract output op and relevant indexing maps
+        output_op = generic_op.outputs[0]
+        output_map = generic_op.indexing_maps.data[-1].data
+        
+        # make some assertions on correct inputs of the linalg generic
+        shaped_inputs = [(op, map.data) for (op, map) in zip(generic_op.inputs, generic_op.indexing_maps.data[:-1]) if isinstance(op.type, ShapedType)]
+        if len(shaped_inputs) != 2:
+            return
+        
+        operands = [shaped_inputs[0][0], shaped_inputs[1][0], output_op]
+        indexing_maps = [shaped_inputs[0][1], shaped_inputs[1][1], output_map]
 
         zigzag_description = dict()
 
@@ -43,20 +55,20 @@ class LinalgToStreamTranslator(RewritePattern):
 
         # construct equation
         output_access = "O"
-        for i in range(len(generic_op.indexing_maps.data[-1].data.results)):
-            map = generic_op.indexing_maps.data[-1].data.results[i]
+        for i in range(len(indexing_maps[-1].results)):
+            map = indexing_maps[-1].results[i]
             assert isinstance(map, AffineDimExpr)
             output_access += f"[{str(map)}]"
        
         input_i_access = "I"
-        for i in range(len(generic_op.indexing_maps.data[0].data.results)):
-            map = generic_op.indexing_maps.data[0].data.results[i]
+        for i in range(len(indexing_maps[0].results)):
+            map = indexing_maps[0].results[i]
             assert isinstance(map, AffineDimExpr)
             input_i_access += f"[{str(map)}]"
 
         input_w_access = "W"
-        for i in range(len(generic_op.indexing_maps.data[1].data.results)):
-            map = generic_op.indexing_maps.data[1].data.results[i]
+        for i in range(len(indexing_maps[1].results)):
+            map = indexing_maps[1].results[i]
             assert isinstance(map, AffineDimExpr)
             input_w_access += f"[{str(map)}]"
 
@@ -77,14 +89,14 @@ class LinalgToStreamTranslator(RewritePattern):
         # extract loop bounds by evaluating the inverse affine map
         # with the memref shapes as input
         results = []
-        results.extend(generic_op.indexing_maps.data[0].data.results)
-        results.extend(generic_op.indexing_maps.data[1].data.results)
-        results.extend(generic_op.indexing_maps.data[2].data.results)
+        results.extend(indexing_maps[0].results)
+        results.extend(indexing_maps[1].results)
+        results.extend(indexing_maps[2].results)
 
         combined_affine_map = AffineMap(3, 0, results)
         inverse_map = combined_affine_map.inverse_permutation()
 
-        memref_shapes = [shape.data for op in generic_op.operands for shape in op.type.shape.data]
+        memref_shapes = [shape.data for op in operands for shape in op.type.shape.data]
         iteration_bounds = inverse_map.eval(memref_shapes, [])
 
         zigzag_description["loop_dim_size"] = dict()
@@ -94,7 +106,7 @@ class LinalgToStreamTranslator(RewritePattern):
 
         # extract operand precision
         widths = []
-        for op in generic_op.operands :
+        for op in operands:
             assert isinstance(op.type, memref.MemRefType)           
             element_type = op.type.get_element_type()
             if(isinstance(element_type, IntegerType)):
@@ -120,8 +132,8 @@ class LinalgToStreamTranslator(RewritePattern):
         # padding (use default of 0 padding for now)
         # affects last two indices of input I
         zigzag_description["padding"] = dict()
-        zigzag_description["padding"][str(generic_op.indexing_maps.data[0].data.results[0]).upper()] = (0,0)
-        zigzag_description["padding"][str(generic_op.indexing_maps.data[0].data.results[1]).upper()] = (0,0)
+        zigzag_description["padding"][str(indexing_maps[0].results[0]).upper()] = (0,0)
+        zigzag_description["padding"][str(indexing_maps[0].results[1]).upper()] = (0,0)
         workload= dict()
         workload[0] = zigzag_description
 


### PR DESCRIPTION
This parses the inputs and puts them in 2 nice lists `operands` and `indexing_maps` which has the fixed order input a, input b, output. 
This enables the `quantized_matmul` test, (and other quantized operations) as these include extra operands which should not be considered for stream/zigzag